### PR TITLE
[RES-849] [optima] Change CMake config dir to be compatible with expected Unix layout

### DIFF
--- a/cmake/OptimaInstallCMakeConfigFiles.cmake
+++ b/cmake/OptimaInstallCMakeConfigFiles.cmake
@@ -1,5 +1,5 @@
 # The path where cmake config files are installed
-set(OPTIMA_INSTALL_CONFIGDIR ${CMAKE_INSTALL_LIBDIR}/cmake/Optima)
+set(OPTIMA_INSTALL_CONFIGDIR ${CMAKE_INSTALL_LIBDIR}/cmake)
 
 install(EXPORT OptimaTargets
     FILE OptimaTargets.cmake


### PR DESCRIPTION
This is necessary to build and use Optima in development mode, as a Reaktoro dependency, when in Linux, otherwise CMake won't find `OptimaConfig.cmake`.